### PR TITLE
luci-app-bandix-plus: bump PKG_VERSION to 0.1.1

### DIFF
--- a/luci-app-bandix-plus/Makefile
+++ b/luci-app-bandix-plus/Makefile
@@ -10,7 +10,7 @@ LUCI_DEPENDS:=+luci-base +luci-lib-jsonc +curl +bandix-plus
 
 PKG_MAINTAINER:=timsaya
 
-PKG_VERSION:=0.1.0
+PKG_VERSION:=0.1.1
 PKG_RELEASE:=1
 
 include $(TOPDIR)/feeds/luci/luci.mk


### PR DESCRIPTION
@Align the LuCI package version with bandix-plus 0.1.1.