### PR TITLE
fix: replace invalid `bandix-plus` UCI references with `bandix_plus`

### DIFF
--- a/luci-app-bandix-plus/htdocs/luci-static/resources/view/bandix_plus/settings.js
+++ b/luci-app-bandix-plus/htdocs/luci-static/resources/view/bandix_plus/settings.js
@@ -17,7 +17,7 @@ function bplusJson(r) {
 return view.extend({
 	load: function () {
 		return Promise.all([
-			uci.load('bandix-plus'),
+			uci.load('bandix_plus'),
 			uci.load('network'),
 			callGetVersion().then(bplusJson)
 		]);
@@ -27,11 +27,11 @@ return view.extend({
 		var m, s, o;
 		var vinfo = load[ 2 ] || {};
 
-		if (!uci.get('bandix-plus', 'general')) {
-			uci.add('bandix-plus', 'bandix_plus', 'general');
+		if (!uci.get('bandix_plus', 'general')) {
+			uci.add('bandix_plus', 'bandix_plus', 'general');
 		}
 
-		m = new form.Map('bandix-plus', _('Bandix Plus'), _('Runtime options for openwrt-bandix-plus service.'));
+		m = new form.Map('bandix_plus', _('Bandix Plus'), _('Runtime options for openwrt-bandix-plus service.'));
 		m.versionInfo = vinfo;
 
 		s = m.section(form.NamedSection, 'general', 'bandix_plus', _('General'));


### PR DESCRIPTION
OpenWrt 24.x enforces stricter rpcd ACL checks.

The settings page was using bandix-plus as the UCI config name, while the actual config file and ACL definitions use bandix_plus.

This caused RPCError: uci/get failed with ubus code 6: Permission denied when opening or saving the settings page.

This PR fixes all incorrect UCI references in settings.js.

----


OpenWrt 24.x 对 rpcd ACL 权限检查变得更加严格。

设置页面中使用了 bandix-plus 作为 UCI 配置名称，但实际的配置文件和 ACL 定义使用的是 bandix_plus。

这会导致在打开或保存设置页面时出现 RPCError: uci/get failed with ubus code 6: Permission denied 错误。

此 PR 修复了 settings.js 中所有错误的 UCI 配置引用。