### PR TITLE
add service status

### DIFF
--- a/luci-app-bandix-plus/htdocs/luci-static/resources/view/bandix_plus/index.js
+++ b/luci-app-bandix-plus/htdocs/luci-static/resources/view/bandix_plus/index.js
@@ -62,6 +62,8 @@ var callGetGuestWhitelist = rpc.declare({ object: 'luci.bandix_plus', method: 'g
 var callAddGuestWhitelist = rpc.declare({ object: 'luci.bandix_plus', method: 'addGuestWhitelist', params: [ 'payload' ], expect: {} });
 var callRemoveGuestWhitelist = rpc.declare({ object: 'luci.bandix_plus', method: 'removeGuestWhitelist', params: [ 'payload' ], expect: {} });
 var callGetVersion = rpc.declare({ object: 'luci.bandix_plus', method: 'getVersion', expect: {} });
+var callGetStatus = rpc.declare({ object: 'luci.bandix_plus', method: 'getStatus', expect: {} });
+var callRestartService = rpc.declare({ object: 'luci.bandix_plus', method: 'restartService', expect: {} });
 
 function bplusJson(r) {
 	if (r == null) return null;
@@ -583,7 +585,22 @@ function ensureLayoutCss() {
 		'.bplus-page .bplus-trend-toolbar,.bplus-page .bplus-device-toolbar{display:flex;flex-wrap:wrap;align-items:center;gap:10px 16px;justify-content:flex-end;}',
 		'.bplus-page .bplus-trend-toolbar .cbi-input-select,.bplus-page .bplus-device-toolbar .cbi-input-select{min-width:6em;}',
 		'.bplus-page .bplus-section{margin-top:1.25rem;}',
-		'.bplus-page .bplus-section>h3{margin:0 0 12px 0;font-size:1.1rem;font-weight:600;}'
+		'.bplus-page .bplus-section>h3{margin:0 0 12px 0;font-size:1.1rem;font-weight:600;}',
+		/* status banner */
+		'.bplus-page .bplus-status-bar{display:flex;flex-wrap:wrap;align-items:stretch;gap:12px;padding:12px 16px;border-radius:12px;border:1px solid var(--bplus-border,#d1d5db);background:var(--bplus-bg,#fff);margin-bottom:14px;}',
+		'.bplus-page .bplus-status-bar.is-down{border-color:#ef4444;background:rgba(239,68,68,0.08);}',
+		'.bplus-page .bplus-status-bar.is-warn{border-color:#f59e0b;background:rgba(245,158,11,0.08);}',
+		'.bplus-page .bplus-status-bar.is-disabled{border-color:#9ca3af;background:rgba(156,163,175,0.10);}',
+		'.bplus-page .bplus-status-cell{flex:1 1 140px;min-width:120px;display:flex;flex-direction:column;gap:2px;padding:0 8px;border-left:1px solid var(--bplus-border,#e5e7eb);}',
+		'.bplus-page .bplus-status-cell:first-child{border-left:0;padding-left:0;}',
+		'.bplus-page .bplus-status-cell .bplus-status-label{font-size:.78rem;opacity:.6;text-transform:uppercase;letter-spacing:.04em;}',
+		'.bplus-page .bplus-status-cell .bplus-status-value{font-size:1rem;font-weight:600;word-break:break-all;}',
+		'.bplus-page .bplus-status-cell .bplus-status-value.is-up{color:#16a34a;}',
+		'.bplus-page .bplus-status-cell .bplus-status-value.is-down{color:#dc2626;}',
+		'.bplus-page .bplus-status-cell .bplus-status-value.is-warn{color:#d97706;}',
+		'.bplus-page .bplus-status-cell .bplus-status-value.is-muted{color:#6b7280;}',
+		'.bplus-page .bplus-status-actions{display:flex;align-items:center;gap:8px;margin-left:auto;padding-left:8px;border-left:1px solid var(--bplus-border,#e5e7eb);}',
+		'.bplus-page .bplus-status-down-notice{padding:18px 16px;border-radius:12px;border:1px dashed var(--bplus-border,#d1d5db);background:var(--bplus-bg,#fff);text-align:center;color:#6b7280;}'
 	].join('');
 	document.head.appendChild(st);
 }
@@ -606,7 +623,7 @@ return view.extend({
 			return uci.load(pkg).catch(function () { return null; });
 		};
 		return Promise.all([
-			uci.load('bandix_plus'),
+			uci.load('bandix-plus'),
 			optionalLoad('luci'),
 			optionalLoad('argon'),
 			optionalLoad('kucat'),
@@ -997,6 +1014,111 @@ return view.extend({
 	setBusy: function (btn, busy) {
 		if (!btn) return;
 		btn.disabled = !!busy;
+	},
+
+	renderStatusBar: function (st) {
+		var bar = this.el && this.el.statusBar;
+		if (!bar) return;
+		st = st || {};
+		var enabled = String(st.enabled) === '1';
+		var running = String(st.running) === '1';
+		var et = String(st.enable_traffic) === '1';
+		var apiOk = String(st.api_health_ok) === '1';
+		var pid = String(st.pid || '');
+
+		var stateLabel, stateCls, barCls;
+		if (!et) {
+			stateLabel = _('Disabled');
+			stateCls = 'is-muted';
+			barCls = 'is-disabled';
+		} else if (running && apiOk) {
+			stateLabel = _('Running');
+			stateCls = 'is-up';
+			barCls = '';
+		} else if (running && !apiOk) {
+			stateLabel = _('API Unreachable');
+			stateCls = 'is-warn';
+			barCls = 'is-warn';
+		} else {
+			stateLabel = _('Stopped');
+			stateCls = 'is-down';
+			barCls = 'is-down';
+		}
+
+		bar.className = 'bplus-status-bar' + (barCls ? ' ' + barCls : '');
+
+		var port = '';
+		try { port = uci.get('bandix-plus', 'general', 'port') || ''; } catch (e) {}
+		if (!port) port = '8787';
+
+		function cell(label, valueText, valueCls) {
+			return E('div', { 'class': 'bplus-status-cell' }, [
+				E('div', { 'class': 'bplus-status-label' }, [ label ]),
+				E('div', { 'class': 'bplus-status-value' + (valueCls ? ' ' + valueCls : '') }, [ valueText ])
+			]);
+		}
+
+		var apiCell = cell(_('API'), apiOk ? _('OK') : _('Fail'), apiOk ? 'is-up' : 'is-down');
+		var pidCell = cell('PID', running && pid ? pid : '—', running ? 'is-up' : 'is-muted');
+		var stateCell = cell(_('State'), stateLabel, stateCls);
+		var enabledCell = cell(_('Auto-start'), enabled ? _('on') : _('off'), enabled ? 'is-up' : 'is-muted');
+		var versionCell = cell(_('Package'), st.bandix_plus_pkg || _('unknown'));
+		var portCell = cell(_('Port'), String(port));
+
+		var restartBtn = E('button', {
+			'type': 'button',
+			'class': 'btn cbi-button cbi-button-action'
+		}, [ _('Restart') ]);
+		restartBtn.addEventListener('click', L.bind(this.handleRestartClick, this));
+
+		var actions = E('div', { 'class': 'bplus-status-actions' }, [ restartBtn ]);
+
+		dom.content(bar, [
+			stateCell, pidCell, apiCell, portCell, enabledCell, versionCell, actions
+		]);
+
+		var down = !(et && running && apiOk);
+		if (this.el.statusDownNotice)
+			this.el.statusDownNotice.style.display = down ? '' : 'none';
+		if (this.el.mainSection)
+			this.el.mainSection.style.display = down ? 'none' : '';
+	},
+
+	handleRestartClick: function (ev) {
+		var btn = ev && ev.currentTarget;
+		this.setBusy(btn, true);
+		var self = this;
+		return callRestartService().then(bplusJson).then(function (r) {
+			if (!r || String(r.ok) !== '1') {
+				ui.addNotification(null, E('p', {}, [ _('Failed to restart bandix-plus') ]), 'error');
+			} else {
+				ui.addNotification(null, E('p', {}, [ _('bandix-plus restart requested') ]), 'info');
+			}
+		}).catch(function (e) {
+			self.notifyError(_('Failed to restart bandix-plus'), e);
+		}).finally(function () {
+			self.setBusy(btn, false);
+			return self.refreshServiceStatus();
+		});
+	},
+
+	refreshServiceStatus: function () {
+		var self = this;
+		return callGetStatus().then(bplusJson).then(function (st) {
+			self.serviceStatus = st || {};
+			self.renderStatusBar(self.serviceStatus);
+			return self.serviceStatus;
+		}).catch(function () {
+			self.serviceStatus = { running: '0', api_health_ok: '0' };
+			self.renderStatusBar(self.serviceStatus);
+		});
+	},
+
+	isServiceUp: function () {
+		var st = this.serviceStatus || {};
+		return String(st.enable_traffic) === '1' &&
+			String(st.running) === '1' &&
+			String(st.api_health_ok) === '1';
 	},
 
 	notifyError: function (msg, err) {
@@ -4081,8 +4203,13 @@ return view.extend({
 		this.el.trendTypeSelect.value = this.selectedTrendType;
 		this.el.statsLoadingNotice = E('div', { 'class': 'bplus-stats-loading-notice', 'style': 'display:none' }, []);
 
-		this.root = E('div', { 'class': 'bplus-page' }, [
-			E('div', { 'class': 'bplus-main' }, [
+		/* Service status banner (top of page) — populated by refreshServiceStatus(). */
+		this.el.statusBar = E('div', { 'class': 'bplus-status-bar' }, []);
+		this.el.statusDownNotice = E('div', {
+			'class': 'bplus-status-down-notice',
+			'style': 'display:none'
+		}, [ _('bandix-plus is not running. Charts and tables are hidden until the service is up.') ]);
+		this.el.mainSection = E('div', { 'class': 'bplus-main' }, [
 				E('section', { 'class': 'bplus-panel' }, [
 					E('div', { 'class': 'bplus-panel-head' }, [
 						E('h2', [ _('Interface Overview') ]),
@@ -4254,7 +4381,12 @@ return view.extend({
 						])
 					])
 				])
-			])
+			]);
+
+		this.root = E('div', { 'class': 'bplus-page' }, [
+			this.el.statusBar,
+			this.el.statusDownNotice,
+			this.el.mainSection
 		]);
 
 		return this.root;
@@ -4284,6 +4416,8 @@ return view.extend({
 		this.el.statsStart.setAttribute('max', cap);
 		this.el.statsEnd.setAttribute('max', cap);
 
+		this.refreshServiceStatus();
+
 		this.refreshLive(false).then(L.bind(function () {
 			if (this.el.statsIface && this.el.statsIface.value) this.queryStats();
 			if (this.el.rankIface && this.el.rankIface.value) this.queryUsageRanking();
@@ -4295,6 +4429,7 @@ return view.extend({
 			poll.add(L.bind(function () {
 				this.setThemeClass();
 				return Promise.all([
+					this.refreshServiceStatus(),
 					this.refreshLive(false),
 					this.refreshRateData(false)
 				]);

--- a/luci-app-bandix-plus/htdocs/luci-static/resources/view/bandix_plus/settings.js
+++ b/luci-app-bandix-plus/htdocs/luci-static/resources/view/bandix_plus/settings.js
@@ -2,37 +2,24 @@
 'require view';
 'require form';
 'require uci';
-'require rpc';
-'require ui';
 'require tools.widgets as widgets';
-var callGetVersion = rpc.declare({ object: 'luci.bandix_plus', method: 'getVersion', expect: {} });
-var callRestart = rpc.declare({ object: 'luci.bandix_plus', method: 'restartService', expect: {} });
-
-function bplusJson(r) {
-	if (r == null) return null;
-	if (typeof r === 'string') return JSON.parse(r);
-	return r;
-}
 
 return view.extend({
 	load: function () {
 		return Promise.all([
-			uci.load('bandix_plus'),
-			uci.load('network'),
-			callGetVersion().then(bplusJson)
+			uci.load('bandix-plus'),
+			uci.load('network')
 		]);
 	},
 
-	render: function (load) {
+	render: function () {
 		var m, s, o;
-		var vinfo = load[ 2 ] || {};
 
-		if (!uci.get('bandix_plus', 'general')) {
-			uci.add('bandix_plus', 'bandix_plus', 'general');
+		if (!uci.get('bandix-plus', 'general')) {
+			uci.add('bandix-plus', 'bandix_plus', 'general');
 		}
 
-		m = new form.Map('bandix_plus', _('Bandix Plus'), _('Runtime options for openwrt-bandix-plus service.'));
-		m.versionInfo = vinfo;
+		m = new form.Map('bandix-plus', _('Bandix Plus'), _('Runtime options for openwrt-bandix-plus service.'));
 
 		s = m.section(form.NamedSection, 'general', 'bandix_plus', _('General'));
 		s.addremove = false;
@@ -98,12 +85,6 @@ return view.extend({
 		o.default = '0';
 		o.rmempty = false;
 
-		// o = s.option(form.Value, 'history_window_minutes', _('History window (minutes)'));
-		// o.datatype = 'uinteger';
-		// o.placeholder = '10';
-		// o.default = '10';
-		// o.rmempty = false;
-
 		o = s.option(form.Value, 'host', _('Host'));
 		o.placeholder = '127.0.0.1';
 		o.default = '127.0.0.1';
@@ -119,24 +100,6 @@ return view.extend({
 		o.placeholder = '/usr/share/bandix-plus';
 		o.default = '/usr/share/bandix-plus';
 		o.rmempty = false;
-
-		o = s.option(form.DummyValue, 'ver', _('Info'));
-		o.cfgvalue = function () {
-			var z = m.versionInfo;
-			if (!z) return '—';
-			return 'bandix-plus ipk: ' + (z.bandix_plus_pkg || '') + ' | /api/health: ' + (z.api_health_ok || '0');
-		};
-
-		o = s.option(form.Button, 'restart', _('Service'));
-		o.inputtitle = _('Restart bandix-plus (init if present)');
-		o.inputstyle = 'action';
-		o.onclick = function () {
-			return callRestart().then(bplusJson).then(function (r) {
-				if (!r || r.ok !== '1') {
-					ui.addNotification(null, E('pre', {}, [ JSON.stringify(r) ]), 'error');
-				}
-			});
-		};
 
 		return m.render();
 	}

--- a/luci-app-bandix-plus/root/etc/config/bandix_plus
+++ b/luci-app-bandix-plus/root/etc/config/bandix_plus
@@ -1,4 +1,0 @@
-# bandix-plus HTTP API (default --api-bind 0.0.0.0:8787)
-# LuCI 仅将 curl 指到 127.0.0.1:port
-config bandix_plus 'general'
-	option port '8787'

--- a/luci-app-bandix-plus/root/etc/uci-defaults/40_luci-bandix-plus
+++ b/luci-app-bandix-plus/root/etc/uci-defaults/40_luci-bandix-plus
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Register bandix-plus UCI changes with LuCI's apply mechanism so that
+# saving the form automatically reloads /etc/init.d/bandix-plus.
+
+uci -q batch <<-EOF >/dev/null
+	delete ucitrack.@bandix-plus[-1]
+	add ucitrack bandix-plus
+	set ucitrack.@bandix-plus[-1].init=bandix-plus
+	commit ucitrack
+EOF
+
+rm -f /tmp/luci-indexcache /tmp/luci-modulecache/* 2>/dev/null
+exit 0

--- a/luci-app-bandix-plus/root/usr/libexec/rpcd/luci.bandix_plus
+++ b/luci-app-bandix-plus/root/usr/libexec/rpcd/luci.bandix_plus
@@ -4,7 +4,7 @@
 
 bplus_base() {
 	local p
-	p="$(uci -q get bandix_plus.general.port)"
+	p="$(uci -q get bandix-plus.general.port)"
 	[ -z "$p" ] && p="8787"
 	printf 'http://127.0.0.1:%s' "$p"
 }
@@ -136,6 +136,8 @@ case "$1" in
 		json_add_string "hostname"
 		json_close_object
 		json_add_object "getVersion"
+		json_close_object
+		json_add_object "getStatus"
 		json_close_object
 		json_add_object "restartService"
 		json_close_object
@@ -419,6 +421,61 @@ case "$1" in
 				json_init
 				json_add_string "bandix_plus_pkg" "${pkgv:-unknown}"
 				json_add_string "api_health_ok" "${api_ok:-0}"
+				json_dump
+				json_cleanup
+				;;
+			getStatus)
+				# enabled: /etc/init.d/bandix-plus enabled exit code (0=enabled)
+				enabled=0
+				if [ -x /etc/init.d/bandix-plus ]; then
+					/etc/init.d/bandix-plus enabled 2>/dev/null && enabled=1
+				fi
+
+				# running/pid: ask procd via ubus
+				running=0
+				pid=0
+				svc_json="$(ubus call service list '{"name":"bandix-plus"}' 2>/dev/null)"
+				if [ -n "$svc_json" ]; then
+					pid="$(echo "$svc_json" | jsonfilter -e '$["bandix-plus"].instances["bandix-plus"].pid' 2>/dev/null)"
+					case "$pid" in
+						''|*[!0-9]*) pid=0 ;;
+					esac
+					[ "$pid" -gt 0 ] 2>/dev/null && running=1
+				fi
+				if [ "$running" -eq 0 ] && [ -f /var/run/bandix-plus.pid ]; then
+					p="$(cat /var/run/bandix-plus.pid 2>/dev/null)"
+					case "$p" in
+						''|*[!0-9]*) ;;
+						*)
+							if [ -d "/proc/$p" ]; then
+								running=1
+								pid="$p"
+							fi
+							;;
+					esac
+				fi
+
+				# uci enable_traffic flag (1 means user wants service running)
+				enable_traffic="$(uci -q get bandix-plus.general.enable_traffic)"
+				[ -z "$enable_traffic" ] && enable_traffic=0
+
+				# api health probe
+				hb=$(bplus_get "$BASE/api/health")
+				api_ok=0
+				echo "$hb" | grep -q '"ok":true' && api_ok=1
+
+				# package version
+				pkgv=""
+				[ -f /usr/lib/opkg/info/bandix-plus.control ] && \
+					pkgv=$(grep "^Version:" /usr/lib/opkg/info/bandix-plus.control 2>/dev/null | cut -d' ' -f2)
+
+				json_init
+				json_add_int    "enabled"         "$enabled"
+				json_add_int    "running"         "$running"
+				json_add_int    "pid"             "$pid"
+				json_add_int    "enable_traffic"  "$enable_traffic"
+				json_add_int    "api_health_ok"   "$api_ok"
+				json_add_string "bandix_plus_pkg" "${pkgv:-unknown}"
 				json_dump
 				json_cleanup
 				;;

--- a/luci-app-bandix-plus/root/usr/share/luci/menu.d/luci-app-bandix-plus.json
+++ b/luci-app-bandix-plus/root/usr/share/luci/menu.d/luci-app-bandix-plus.json
@@ -8,7 +8,7 @@
 		},
 		"depends": {
 			"acl": [ "luci-app-bandix-plus" ],
-			"uci": { "bandix_plus": true }
+			"uci": { "bandix-plus": true }
 		}
 	},
 	"admin/network/bandix_plus/index": {

--- a/luci-app-bandix-plus/root/usr/share/rpcd/acl.d/luci-app-bandix-plus.json
+++ b/luci-app-bandix-plus/root/usr/share/rpcd/acl.d/luci-app-bandix-plus.json
@@ -16,10 +16,11 @@
 					"getIfaceLimits",
 					"getGuestDefaults",
 					"getGuestWhitelist",
-					"getVersion"
+					"getVersion",
+					"getStatus"
 				]
 			},
-			"uci": [ "bandix_plus" ]
+			"uci": [ "bandix-plus" ]
 		},
 		"write": {
 			"ubus": {
@@ -37,6 +38,7 @@
 					"getGuestDefaults",
 					"getGuestWhitelist",
 					"getVersion",
+					"getStatus",
 					"createSchedule",
 					"updateSchedule",
 					"deleteSchedule",
@@ -51,7 +53,7 @@
 					"restartService"
 				]
 			},
-			"uci": [ "bandix_plus" ]
+			"uci": [ "bandix-plus" ]
 		}
 	}
 }


### PR DESCRIPTION
# 功能描述
1. 首页增加了后台程序运行状态 #14 
<img width="1180" height="309" alt="image" src="https://github.com/user-attachments/assets/7b482a33-685a-48cb-ae6b-2ba9e720bbf4" />

2. 合并了配置文件，现在luci直接使用后端的配置文件
3. 现在修改配置文件会自动起停后端程序
4. 后端程序未启动的时候隐藏图表
<img width="1209" height="427" alt="image" src="https://github.com/user-attachments/assets/4392b92f-13a2-4c20-96e3-3da0b1d1301c" />

# 其他说明
代码编写过程中使用了AI

# 测试包
[luci-app-bandix-plus_0.1.1-r1_all.ipk.zip](https://github.com/user-attachments/files/28013376/luci-app-bandix-plus_0.1.1-r1_all.ipk.zip)

