### PR TITLE
优化概览卡片响应式布局

### DIFF
--- a/luci-app-bandix-plus/htdocs/luci-static/resources/bandix_plus/status.css
+++ b/luci-app-bandix-plus/htdocs/luci-static/resources/bandix_plus/status.css
@@ -871,7 +871,7 @@
 
 .bplus-page .overview-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(350px, 1fr));
   gap: 12px;
   width: 100%;
   min-width: 0;
@@ -909,7 +909,7 @@
 }
 
 .bplus-page .overview-card {
-  min-width: 0;
+  min-width: min(100%, 350px);
   max-width: 100%;
   border: 1px solid var(--bplus-border);
   border-radius: 14px;
@@ -917,6 +917,30 @@
   background: var(--bplus-card);
   display: grid;
   gap: 12px;
+}
+
+@media (max-width: 1180px) {
+  .bplus-page .overview-grid {
+    grid-template-columns: repeat(2, minmax(350px, 1fr));
+  }
+
+  .bplus-page .overview-grid:has(> .overview-card:nth-child(3n + 1):last-child) > .overview-card:nth-child(3n + 1):last-child {
+    grid-column: auto;
+  }
+
+  .bplus-page .overview-grid:has(> .overview-card:nth-child(2n + 1):last-child) > .overview-card:nth-child(2n + 1):last-child {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 768px) {
+  .bplus-page .overview-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .bplus-page .overview-card {
+    min-width: 0;
+  }
 }
 
 /* 使用 div 而非 header：LuCI 主题常给 <header> 加左侧色条；与 luci-app-bandix .device-card-header 一致 */


### PR DESCRIPTION
## 摘要

- 将概览卡片网格改为按最小 350px 自动排布
- 卡片可随可用空间扩展，不再把最大宽度固定为 350px
- 移除最后一张卡片拉满整行的规则，宽屏可自然显示 3+1
- 手机端保持一行显示一个卡片，并占满可用宽度

## 背景

当前概览区域使用三列弹性布局时，卡片在部分宽度下会被压得过窄；之前固定 350px 最大宽度又会导致手机或较窄容器中卡片不能充分利用空间。

此调整使用 `auto-fill` 与 `minmax(min(100%, 350px), 1fr)`，让卡片至少按 350px 规划列宽，同时能够随容器宽度扩展。宽屏能放三张时显示 3+1，窄屏和手机端则自动降为单列。

## 测试

- 在 OpenWrt 设备上部署更新后的 `status.css`
- 验证宽屏下可显示 3+1 布局
- 验证较窄宽度下卡片会占满可用列宽
- 验证手机端断点下一行只显示一个卡片