### PR TITLE
优化概览网格填充行为

### DIFF
--- a/luci-app-bandix-plus/htdocs/luci-static/resources/bandix_plus/status.css
+++ b/luci-app-bandix-plus/htdocs/luci-static/resources/bandix_plus/status.css
@@ -871,21 +871,11 @@
 
 .bplus-page .overview-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(350px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 350px), 1fr));
   gap: 12px;
   width: 100%;
   min-width: 0;
   box-sizing: border-box;
-}
-
-/* 仅 1 张接口卡时占满一行 */
-.bplus-page .overview-grid > .overview-card:only-of-type {
-  grid-column: 1 / -1;
-}
-
-/* 每行最多 3 张；若最后一行只余 1 张（1、4、7… 张时最后一张），拉满该行 */
-.bplus-page .overview-grid:has(> .overview-card:nth-child(3n + 1):last-child) > .overview-card:nth-child(3n + 1):last-child {
-  grid-column: 1 / -1;
 }
 
 .bplus-page .overview-state {
@@ -909,7 +899,7 @@
 }
 
 .bplus-page .overview-card {
-  min-width: min(100%, 350px);
+  min-width: 0;
   max-width: 100%;
   border: 1px solid var(--bplus-border);
   border-radius: 14px;
@@ -919,27 +909,9 @@
   gap: 12px;
 }
 
-@media (max-width: 1180px) {
-  .bplus-page .overview-grid {
-    grid-template-columns: repeat(2, minmax(350px, 1fr));
-  }
-
-  .bplus-page .overview-grid:has(> .overview-card:nth-child(3n + 1):last-child) > .overview-card:nth-child(3n + 1):last-child {
-    grid-column: auto;
-  }
-
-  .bplus-page .overview-grid:has(> .overview-card:nth-child(2n + 1):last-child) > .overview-card:nth-child(2n + 1):last-child {
-    grid-column: 1 / -1;
-  }
-}
-
 @media (max-width: 768px) {
   .bplus-page .overview-grid {
     grid-template-columns: 1fr;
-  }
-
-  .bplus-page .overview-card {
-    min-width: 0;
   }
 }
 


### PR DESCRIPTION
## 摘要

- 将概览网格改为 `auto-fill` 自动排布
- 使用 `minmax(min(100%, 350px), 1fr)`，让卡片至少按 350px 规划列宽，但可以吃满可用空间
- 移除单张或最后一张卡片拉满整行的规则
- 手机端仍保持一行一个卡片，并占满可用宽度

## 背景

上一版布局在部分宽度下会变成固定两列，导致 646px 这类宽度只能显示一张；同时固定最大 350px 又会让窄屏卡片无法占满可用空间。

此调整让布局根据容器宽度自然决定列数：能放三张时显示 3+1，放不下时降列，单列时卡片占满整行。

## 测试

- 在 OpenWrt 设备上部署更新后的 `status.css`
- 验证 646px 左右宽度下单列卡片占满可用宽度
- 验证宽屏可自然显示 3+1
- 验证手机端一行显示一个卡片