### PR TITLE
Expose traffic persistence controls

### DIFF
--- a/luci-app-bandix-plus/htdocs/luci-static/resources/view/bandix_plus/settings.js
+++ b/luci-app-bandix-plus/htdocs/luci-static/resources/view/bandix_plus/settings.js
@@ -1,11 +1,13 @@
 'use strict';
 'require view';
 'require form';
+'require ui';
 'require uci';
 'require rpc';
 'require tools.widgets as widgets';
 
 var callRestartService = rpc.declare({ object: 'luci.bandix_plus', method: 'restartService', expect: {} });
+var callPersistTraffic = rpc.declare({ object: 'luci.bandix_plus', method: 'persistTraffic', expect: {} });
 
 return view.extend({
 	load: function () {
@@ -87,6 +89,35 @@ return view.extend({
 		o = s.option(form.Flag, 'traffic_enable_storage', _('Enable traffic persistence storage'), _('Persist traffic histogram/ring data to disk. Disabled by default.'));
 		o.default = '0';
 		o.rmempty = false;
+
+		o = s.option(form.ListValue, 'traffic_flush_interval', _('Data Flush Interval'), _('Set the interval for flushing traffic data to disk.'));
+		o.value('60', _('1 minute'));
+		o.value('300', _('5 minutes'));
+		o.value('600', _('10 minutes'));
+		o.value('900', _('15 minutes'));
+		o.value('1800', _('30 minutes'));
+		o.value('3600', _('1 hour'));
+		o.value('7200', _('2 hours'));
+		o.value('43200', _('12 hours'));
+		o.value('86400', _('24 hours'));
+		o.default = '600';
+		o.rmempty = false;
+		o.depends('traffic_enable_storage', '1');
+
+		o = s.option(form.Button, '_persist_traffic', _('Save traffic data now'), _('Immediately ask bandix-plus to flush current traffic data to disk.'));
+		o.inputtitle = _('Save traffic data now');
+		o.inputstyle = 'apply';
+		o.depends('traffic_enable_storage', '1');
+		o.onclick = function () {
+			return callPersistTraffic().then(function (res) {
+				if (res && res.ok === false)
+					ui.addNotification(null, E('p', _('Failed to save traffic data: ') + (res.error || _('Unknown error'))), 'error');
+				else
+					ui.addNotification(null, E('p', _('Traffic data saved.')), 'info');
+			}).catch(function (err) {
+				ui.addNotification(null, E('p', _('Failed to save traffic data: ') + (err.message || err)), 'error');
+			});
+		};
 
 		o = s.option(form.Value, 'host', _('Host'));
 		o.placeholder = '127.0.0.1';

--- a/luci-app-bandix-plus/root/usr/libexec/rpcd/luci.bandix_plus
+++ b/luci-app-bandix-plus/root/usr/libexec/rpcd/luci.bandix_plus
@@ -21,6 +21,39 @@ bplus_post_json() {
 	curl -s -g --connect-timeout 2 --max-time 20 -X POST -H "Content-Type: application/json" -d "$1" "$2"
 }
 
+bplus_post_json_checked() {
+	local body="$1"
+	local url="$2"
+	local tmp="/tmp/luci-bandix-plus-curl.$$"
+	local code
+	local resp
+
+	code="$(curl -s -g --connect-timeout 2 --max-time 20 -X POST -H "Content-Type: application/json" -d "$body" -o "$tmp" -w "%{http_code}" "$url")"
+	resp="$(cat "$tmp" 2>/dev/null)"
+	rm -f "$tmp"
+
+	case "$code" in
+		2??)
+			[ -n "$resp" ] && printf '%s' "$resp" || printf '%s\n' '{"ok":true,"data":null,"error":null}'
+		;;
+		404)
+			printf '%s\n' '{"ok":false,"data":null,"error":"backend does not support /api/traffic/persist"}'
+		;;
+		000)
+			printf '%s\n' '{"ok":false,"data":null,"error":"bandix-plus backend is not reachable"}'
+		;;
+		*)
+			json_init
+			json_add_boolean "ok" 0
+			json_add_string "data" "error"
+			json_add_string "error" "backend request failed with HTTP $code"
+			[ -n "$resp" ] && json_add_string "response" "$resp"
+			json_dump
+			json_cleanup
+		;;
+	esac
+}
+
 bplus_delete() {
 	curl -s -g --connect-timeout 2 --max-time 20 -X DELETE "$1"
 }
@@ -140,6 +173,8 @@ case "$1" in
 		json_add_object "getStatus"
 		json_close_object
 		json_add_object "restartService"
+		json_close_object
+		json_add_object "persistTraffic"
 		json_close_object
 		json_dump
 		json_cleanup
@@ -502,6 +537,9 @@ case "$1" in
 			restartService)
 				( sleep 1; /etc/init.d/bandix-plus restart ) >/dev/null 2>&1 &
 				json_init; json_add_string ok "1"; json_dump; json_cleanup
+				;;
+			persistTraffic)
+				bplus_post_json_checked '{}' "$BASE/api/traffic/persist"
 				;;
 		esac
 		;;

--- a/luci-app-bandix-plus/root/usr/share/rpcd/acl.d/luci-app-bandix-plus.json
+++ b/luci-app-bandix-plus/root/usr/share/rpcd/acl.d/luci-app-bandix-plus.json
@@ -50,7 +50,8 @@
 					"addGuestWhitelist",
 					"removeGuestWhitelist",
 					"setDeviceHostname",
-					"restartService"
+					"restartService",
+					"persistTraffic"
 				]
 			},
 			"uci": [ "bandix_plus" ]


### PR DESCRIPTION
### 变更内容

本 PR 在 LuCI 设置页暴露 bandix-plus 已有的流量持久化能力：

- 设置页新增 `Data Flush Interval`，可配置流量数据落盘间隔
- 设置页新增 `Save traffic data now` 按钮，可立即触发保存
- rpcd 新增 `persistTraffic` 方法，代理到后端 `POST /api/traffic/persist`
- ACL 增加 `persistTraffic` 写权限
- 当后端不可达、或旧版本后端不支持 `/api/traffic/persist` 时，rpcd 返回明确 JSON 错误，避免前端解析失败

### 验证

- `node --check luci-app-bandix-plus/htdocs/luci-static/resources/view/bandix_plus/settings.js` 通过
- `sh -n luci-app-bandix-plus/root/usr/libexec/rpcd/luci.bandix_plus` 通过
- `jq empty luci-app-bandix-plus/root/usr/share/rpcd/acl.d/luci-app-bandix-plus.json` 通过